### PR TITLE
fix failed to precompile error

### DIFF
--- a/src/HDBSCAN.jl
+++ b/src/HDBSCAN.jl
@@ -5,7 +5,7 @@ export hdbscan, probabilities, exemplars, outlier_scores, leaf_size
 const hdbs = PyNULL()
 
 function __init__()
-    @eval global hdbs = pyimport("hdbscan")
+    copy!(hdbs, pyimport("hdbscan"))
 end
 
 """


### PR DESCRIPTION
Using HDBSCAN from a Julia package produces the following error.
```julia
julia> using TestHDBSCAN
[ Info: Precompiling TestHDBSCAN [ee8c2f5a-dae1-4ee5-bd4a-6f709fd1e75f]
ERROR: LoadError: InitError: Evaluation into the closed module `HDBSCAN` breaks incremental compilation because the side effects will not be permanent. This is likely due to some other module mutating `HDBSCAN` with `eval` during precompilation - don't do this.
```
`TestHDBSCAN` is a dummy package.
```julia
module TestHDBSCAN

using HDBSCAN

end # module
```
Julia and package versions:
```julia
julia> versioninfo()
Julia Version 1.5.3
Commit 788b2c77c1 (2020-11-09 13:37 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Xeon(R) CPU E5-1630 v3 @ 3.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-9.0.1 (ORCJIT, haswell)

(TestHDBSCAN) pkg> st
Project TestHDBSCAN v0.1.0
Status `~/projects/tmp/TestHDBSCAN/Project.toml`
  [dbf13d8f] HDBSCAN v0.1.0 `https://github.com/baggepinnen/HDBSCAN.jl.git#master`
```
Following the instruction from [PyCall](https://github.com/JuliaPy/PyCall.jl#using-pycall-from-julia-modules) could potentially solve this issue.
```julia
(TestHDBSCAN) pkg> st
Project TestHDBSCAN v0.1.0
Status `~/projects/tmp/TestHDBSCAN/Project.toml`
  [dbf13d8f] HDBSCAN v0.1.0 `https://github.com/ymtoo/HDBSCAN.jl.git#patch-1`

julia> using TestHDBSCAN
[ Info: Precompiling TestHDBSCAN [ee8c2f5a-dae1-4ee5-bd4a-6f709fd1e75f]
```